### PR TITLE
Matplotlib/scipy/numpy from apt sources required for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="/usr/local/go/bin:/usr/local/work/bin:${PATH}"
 ENV GOPATH /usr/local/work
 ENV GO111MODULE=on
 # RUN apt-get update && apt-get -y upgrade && \
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y wget git libc6-dev make pkg-config g++ gcc mosquitto-clients mosquitto python3 python3-dev python3-pip python3-setuptools python3-wheel supervisor libfreetype6-dev && \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y wget git libc6-dev make pkg-config g++ gcc mosquitto-clients mosquitto python3 python3-dev python3-pip python3-setuptools python3-wheel supervisor libfreetype6-dev python3-matplotlib python3-scipy python3-numpy libopenblas-dev libblas-dev liblapack-dev gfortran && \
 	mkdir /usr/local/work && \
 	rm -rf /var/lib/apt/lists/* && \
 	set -eux; \


### PR DESCRIPTION
This allows a successful Docker build on the RPi3 (and likely a successful Docker build on other debian variants as well). Tested in the last few days and no issues found. So the "hard way" compilation is no longer required.
Updating to Golang 1.12 might be interesting here as well.