### PR TITLE
Make requirement less strict for numpy

### DIFF
--- a/server/ai/requirements.txt
+++ b/server/ai/requirements.txt
@@ -11,7 +11,7 @@ Jinja2==2.10
 kiwisolver==1.0.1
 MarkupSafe==1.0
 matplotlib==2.2.3
-numpy==1.15.1
+numpy>=1.15.1,<2.0
 pyparsing==2.2.1
 python-dateutil==2.7.3
 pytz==2018.5


### PR DESCRIPTION
Allow usage of system installation of numpy.

I made a updated Dockerfile without mosquitto (I will probably share it if interested) for raspberry (using external mosquitto).
Because the requirements are too strict, pip doesn't pick up the version installed by apt (v1.16.2 in my case, from https://packages.debian.org/buster/python3-numpy).

Numpy is hard to compile on a raspberry, and even failed in my case for some reasons.