### PR TITLE
Updated paths to images in documentation to fix broken links

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -54,7 +54,7 @@ func NewServer(docs string) (http.Handler, error) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", http.HandlerFunc(s.handleDoc))
-	mux.Handle("/images/", http.FileServer(http.Dir(docs)))
+	mux.Handle("/doc/images/", http.FileServer(http.Dir(docs)))
 	mux.Handle("/issue/", redirectHandler("/issue/", "https://github.com/schollz/find3/issues/"))
 	s.handlers = goGetHandler{gziphandler.GzipHandler(canonicalHostHandler{mux})}
 

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1,6 +1,6 @@
-# FIND Documentation 
+# FIND Documentation
 
-<img src="/images/find_logo.png" width="180px" alt="Home"/>
+<img src="/doc/images/find_logo.png" width="180px" alt="Home"/>
 
 Have you ever wanted to...
 
@@ -35,7 +35,7 @@ To get started, read the documentation and take a look at the repo. The easiest 
 
 - The [`find3-server`](/doc/server_setup.md) document explains how
   to set up your own FIND3 installation on a Linux server.
-  
+
 - The [`esp-client`](https://github.com/DatanoiseTV/esp-find3-client) is a repo that can be used to setup a scanner using ESP8266/ESP32.
 
 ## Applications
@@ -60,5 +60,3 @@ mailing lists, user forums, and so on.
     a low-traffic list for important announcements about the project;
     all FIND3 users should subscribe.
 - [Contribution guidelines](https://github.com/schollz/find3/blob/master/CONTRIBUTING.md)
-
-

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -156,17 +156,17 @@ It depends. This system harnesses the available WiFi routers and Bluetooth devic
 To see whether your fingerprints are resolving well, you should do learning and then check the "Location analysis" at https://cloud.internalpositioning.com. This location analysis shows charts of access point raw data, and if two charts are very similar looking then they are likely too close together to resolve. For example, here is learning data for my desk and my kitchen - which are only about 10 feet apart and there is no wall between them.. You can see that there is little difference between the graphs:
 
 <center>
-<img src="/images/desk.png">
+<img src="/doc/images/desk.png">
 </center>
 
 <center>
-<img src="/images/kitchen.png">
+<img src="/doc/images/kitchen.png">
 </center>
 
 This indicates that these two places are probably too close together. Compare this to another room that is 10 feet away but is separated by a wall - you can see that its analysis looks very different from the other two so it will resolve well.
 
 <center>
-<img src="/images/guest room.png">
+<img src="/doc/images/guest room.png">
 </center>
 
 
@@ -179,7 +179,7 @@ Yes, because floors tend to attenuate the signal, so there is a noticeable diffe
 At a minimum you you should do learning in each location for about 5 minutes. After that, you can go to the dashboard to see the results of your training. To see the dashboard, goto [cloud.internalpositioning.com](https://cloud.internalpositioning.com) and sign in with your family name. At the dashboard you will the results from the last calibration, which may look like:
 
 <center>
-<img src="/images/accuracy2.png">
+<img src="/doc/images/accuracy2.png">
 </center>
 
 The **Overall** gives the average accuracy, while the accuracy for other locations are also shown. These accuracies are determined by cross-validation, so they their representation of reality will correlate with the amount of data available.
@@ -187,19 +187,19 @@ The **Overall** gives the average accuracy, while the accuracy for other locatio
 If you see that one of the locations has low accuracy, then you should do more learning. To do more learning, simply take your device and send sensor data with the given location. Then, when you are done you can re-calibrate by hitting the calibrate button.
 
 <center>
-<img src="/images/calibrate.png">
+<img src="/doc/images/calibrate.png">
 </center>
 
 As an example, when starting learning I noticed I had low accuracy for the "Bathroom" location. I opened the dashboard to see that the accuracy was 50% (not very good).
 
 <center>
-<img src="/images/accuracy50_ss.png" width="70%">
+<img src="/doc/images/accuracy50_ss.png" width="70%">
 </center>
 
 To amend this I did more learning at that location and then I reloaded the browser with the dashboard again to see the results. After inserting about 70 more data, I had increased the accuracy to 87%.
 
 <center>
-<img src="/images/accuracy87.png" width="70%">
+<img src="/doc/images/accuracy87.png" width="70%">
 </center>
 
 At this point, the accuracy had improved enough for me to move on to learn other locations. *Note:* as you learn new locations, they might end up being too similar to previous locations which could decrease the accuracy of previously learned locations. This is dependent on the number of available sensor points in the vicinity.

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
 # Framework for Internal Navigation and Discovery (FIND3)
 
-<img src="/images/find_logo.png" width="180px" alt="Home"/>
+<img src="/doc/images/find_logo.png" width="180px" alt="Home"/>
 
 Have you ever wanted to...
 

--- a/doc/templates/base.tmpl
+++ b/doc/templates/base.tmpl
@@ -6,7 +6,7 @@ license that can be found in the LICENSE file.
 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="icon" type="image/png" href="/images/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="/doc/images/favicon-32x32.png" sizes="32x32">
 <title>{{block "title" .}}FIND3{{end}}</title>
 <style>
 *,

--- a/doc/tracking_your_phone.md
+++ b/doc/tracking_your_phone.md
@@ -14,13 +14,13 @@ First download the latest version of the Android app from Google Play. [Click he
 
 Find the app on your phone and start it up. When you start you will encounter a prompt about accessing the device's location. Though FIND3 does *not* use GPS, Android devices require location permissions in order to access WiFi and Bluetooth settings. **Press "ALLOW" to continue.**
 
-<center><img src="/images/snap1.PNG" width="30%" height="30%"></center>
+<center><img src="/doc/images/snap1.PNG" width="30%" height="30%"></center>
 
 ### Enter information
 
 When you open the app for the first time you will encounter empty textfields that require data.
 
-<center><img src="/images/1.PNG" width="30%" height="30%"></center>
+<center><img src="/doc/images/1.PNG" width="30%" height="30%"></center>
 
 To get started, enter in a **family** name. The **family** is used to distinguish your group of devices. It can be anything you want, but remember it because you will need it to see your results.
 
@@ -34,7 +34,7 @@ to the address of your self-hosted server, `http://YOURADDRESS` (make sure to ke
 
 The first thing you need to do after entering data is to **learn the locations for tracking.** This requires walking to each room and doing a scan for about 5 minutes. 
 
-<center><img src="/images/2.PNG" width="30%" height="30%"></center>
+<center><img src="/doc/images/2.PNG" width="30%" height="30%"></center>
 
 Go to a location, like your *kitchen*, *bathroom* or *living room* and enter the name of the location where it says **location (optional)**. Then hit **TRACKING** so it turns to **LEARNING**.  Then hit **START SCAN** and wait about 5 minutes. Then press **STOP SCAN** and repeat this process in each room, for every room you want to learn.
 
@@ -44,12 +44,12 @@ Go to a location, like your *kitchen*, *bathroom* or *living room* and enter the
 
 Once you are done learning, simply hit the **LEARNING** button so it toggles back to **TRACKING** and then do **START SCAN**.
 
-<center><img src="/images/3.PNG" width="30%" height="30%"></center>
+<center><img src="/doc/images/3.PNG" width="30%" height="30%"></center>
 
 
 Tracking will continue in the background and will show a notification that you can use to toggle the tracking off. There is an option that says "**Allow GPS**". If activated, the phone will send GPS coordinates if requested by the server. 
 
-<center><img src="/images/backgroundscanning.png" width=70%></center>
+<center><img src="/doc/images/backgroundscanning.png" width=70%></center>
 
 The scans will take place approximately 10-30 seconds apart, forever, until you turn off the app. You can turn the app off by clicking the back button. The battery usage is minimal since it is doing only a short WiFi scan and Bluetooth scan.
 


### PR DESCRIPTION
In the current state all images in the documentation are broken cause they were moved from `/images/...` -> `/doc/images/...` without updating the links in the documentation. 

In this fork I updated all of these links and removed some spaces at the end of a line. 